### PR TITLE
Update hide BBCode to require topic participation

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -3,6 +3,10 @@ services:
         class: alfredoramos\hide\event\listener
         arguments:
             - '@alfredoramos.hide.helper'
+            - '@dbal.conn'
+            - '@auth'
+            - '@request'
+            - '@user'
         tags:
             - { name: event.listener }
 

--- a/event/listener.php
+++ b/event/listener.php
@@ -11,11 +11,27 @@ namespace alfredoramos\hide\event;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use alfredoramos\hide\includes\helper;
+use phpbb\db\driver\factory as database;
+use phpbb\auth\auth;
+use phpbb\request\request_interface;
+use phpbb\user;
 
 class listener implements EventSubscriberInterface
 {
-	/** @var helper */
-	protected $helper;
+        /** @var helper */
+        protected $helper;
+
+       /** @var database */
+       protected $db;
+
+       /** @var auth */
+       protected $auth;
+
+       /** @var request_interface */
+       protected $request;
+
+       /** @var user */
+       protected $user;
 
 	/**
 	 * Listener constructor.
@@ -24,10 +40,14 @@ class listener implements EventSubscriberInterface
 	 *
 	 * @return void
 	 */
-	public function __construct(helper $helper)
-	{
-		$this->helper = $helper;
-	}
+       public function __construct(helper $helper, database $db, auth $auth, request_interface $request, user $user)
+       {
+               $this->helper = $helper;
+               $this->db = $db;
+               $this->auth = $auth;
+               $this->request = $request;
+               $this->user = $user;
+       }
 
 	/**
 	 * Assign functions defined in this class to event listeners in the core.
@@ -36,12 +56,13 @@ class listener implements EventSubscriberInterface
 	 */
 	static public function getSubscribedEvents()
 	{
-		return [
-			'core.user_setup' => 'user_setup',
-			'core.text_formatter_s9e_configure_after' => 'configure_hide',
-			'core.feed_modify_feed_row' => 'clean_feed'
-		];
-	}
+               return [
+                       'core.user_setup' => 'user_setup',
+                       'core.text_formatter_s9e_configure_after' => 'configure_hide',
+                       'core.feed_modify_feed_row' => 'clean_feed',
+                       'core.text_formatter_s9e_render_before' => 'set_parameters'
+               ];
+       }
 
 	/**
 	 * Load language files and modify user data on every page.
@@ -97,12 +118,40 @@ class listener implements EventSubscriberInterface
 	 *
 	 * @return void
 	 */
-	public function clean_feed($event)
-	{
-		$event['row'] = array_merge($event['row'], [
-			$event['feed']->get('text') => $this->helper->remove_feed_bbcode(
-				$event['row'][$event['feed']->get('text')]
-			)
-		]);
-	}
+        public function clean_feed($event)
+        {
+                $event['row'] = array_merge($event['row'], [
+                        $event['feed']->get('text') => $this->helper->remove_feed_bbcode(
+                                $event['row'][$event['feed']->get('text')]
+                        )
+                ]);
+        }
+
+       /**
+        * Set renderer parameters.
+        *
+        * @param object $event
+        *
+        * @return void
+        */
+       public function set_parameters($event)
+       {
+               $renderer = $event['renderer'];
+
+               $topic_id = $this->request->variable('t', 0);
+               $has_posted = false;
+
+               if ($this->user->data['user_id'] && $topic_id)
+               {
+                       $sql = 'SELECT 1 FROM ' . POSTS_TABLE . '
+                               WHERE topic_id = ' . (int) $topic_id . '
+                               AND poster_id = ' . (int) $this->user->data['user_id'];
+                       $result = $this->db->sql_query_limit($sql, 1);
+                       $has_posted = (bool) $this->db->sql_fetchrow($result);
+                       $this->db->sql_freeresult($result);
+               }
+
+               $renderer->setParameter('S_HAS_POSTED', $has_posted);
+               $renderer->setParameter('S_IS_ADMIN', $this->auth->acl_get('a_'));
+       }
 }

--- a/language/en/posting.php
+++ b/language/en/posting.php
@@ -27,5 +27,5 @@ $lang = array_merge($lang, [
 	'HIDE' => 'Hide',
 	'HIDE_HELPLINE' => 'Usage: [hide]text[/hide] or [hide inline=1]text[/hide]',
 	'HIDDEN_CONTENT' => 'Hidden content',
-	'HIDDEN_CONTENT_EXPLAIN' => 'Exclusive content for logged in users.'
+       'HIDDEN_CONTENT_EXPLAIN' => 'You must participate in this discussion to view hidden content.'
 ]);

--- a/styles/all/template/hide.xsl
+++ b/styles/all/template/hide.xsl
@@ -1,5 +1,7 @@
+<xsl:param name="S_HAS_POSTED"/>
+<xsl:param name="S_IS_ADMIN"/>
 <xsl:choose>
-	<xsl:when test="$S_USER_LOGGED_IN and not($S_IS_BOT)">
+       <xsl:when test="$S_USER_LOGGED_IN and not($S_IS_BOT) and ($S_HAS_POSTED or $S_IS_ADMIN)">
 		<section>
 			<xsl:attribute name="class">
 				<xsl:choose>


### PR DESCRIPTION
## Summary
- pass new dependencies to the listener
- record whether the current user has posted in topic
- expose these new parameters to the renderer
- display hidden content only to admins or participants
- update the hidden message text

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `phpunit -c phpunit.xml.dist tests/event/listener_test.php` *(fails: command not found)*
- `./vendor/bin/phpunit -c phpunit.xml.dist` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8dd5157483289cecab5664b1a364