### PR TITLE
Fix hide BBCode template

### DIFF
--- a/styles/all/template/hide.xsl
+++ b/styles/all/template/hide.xsl
@@ -1,5 +1,3 @@
-<xsl:param name="S_HAS_POSTED"/>
-<xsl:param name="S_IS_ADMIN"/>
 <xsl:choose>
        <xsl:when test="$S_USER_LOGGED_IN and not($S_IS_BOT) and ($S_HAS_POSTED or $S_IS_ADMIN)">
 		<section>


### PR DESCRIPTION
## Summary
- remove unsupported `<xsl:param>` declarations from the XSL template

## Testing
- `phpunit -c phpunit.xml.dist tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c94173d68832883e39de795228ae4