### PR TITLE
Fix setParameter error for older phpBB

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -151,7 +151,15 @@ class listener implements EventSubscriberInterface
                        $this->db->sql_freeresult($result);
                }
 
-               $renderer->setParameter('S_HAS_POSTED', $has_posted);
-               $renderer->setParameter('S_IS_ADMIN', $this->auth->acl_get('a_'));
+               if (method_exists($renderer, 'setParameter'))
+               {
+                       $renderer->setParameter('S_HAS_POSTED', $has_posted);
+                       $renderer->setParameter('S_IS_ADMIN', $this->auth->acl_get('a_'));
+               }
+               else if (property_exists($renderer, 'params'))
+               {
+                       $renderer->params['S_HAS_POSTED'] = $has_posted;
+                       $renderer->params['S_IS_ADMIN'] = $this->auth->acl_get('a_');
+               }
        }
 }


### PR DESCRIPTION
## Summary
- avoid undefined method errors if renderer doesn't support `setParameter`

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c9a20490083288712e5452a79864d