### PR TITLE
Fix hidden content logic and add French translation

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -139,6 +139,21 @@ class listener implements EventSubscriberInterface
                $renderer = $event['renderer'];
 
                $topic_id = $this->request->variable('t', 0);
+
+               // When only a post id is present get the topic id
+               if (!$topic_id)
+               {
+                       $post_id = $this->request->variable('p', 0);
+
+                       if ($post_id)
+                       {
+                               $sql = 'SELECT topic_id FROM ' . POSTS_TABLE . '
+                                       WHERE post_id = ' . (int) $post_id;
+                               $result = $this->db->sql_query_limit($sql, 1);
+                               $topic_id = (int) $this->db->sql_fetchfield('topic_id');
+                               $this->db->sql_freeresult($result);
+                       }
+               }
                $has_posted = false;
 
                if ($this->user->data['user_id'] && $topic_id)

--- a/language/fr/posting.php
+++ b/language/fr/posting.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Hide extension for phpBB.
+ */
+
+if (!defined('IN_PHPBB'))
+{
+    exit;
+}
+
+if (empty($lang) || !is_array($lang))
+{
+    $lang = [];
+}
+
+$lang = array_merge($lang, [
+    'HIDE' => 'Cacher',
+    'HIDE_HELPLINE' => 'Usage : [hide]texte[/hide] ou [hide inline=1]texte[/hide]',
+    'HIDDEN_CONTENT' => 'Contenu caché',
+    'HIDDEN_CONTENT_EXPLAIN' => 'Vous devez participer à cette discussion pour voir le contenu caché.'
+]);
+


### PR DESCRIPTION
## Summary
- detect topic ID using post ID when `t` parameter is missing
- add French translation file

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c9eab7c04832881375d182d9fe579