### PR TITLE
Fix namespace and translations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  EXTNAME: 'alfredoramos/hide'
+  EXTNAME: 'noordo/hide'
   SNIFF: 1
   IMAGE_ICC: 1
   EPV: 1

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ Extension BBCode Hide améliorée pour phpBB.
 ## Fonctionnalités principales
 
 - Quatre modes d’utilisation :
-- `[hide]texte[/hide]`  
+- `[hide]texte[/hide]`
   → Caché aux membres n’ayant pas posté et aux invités
 
-- `[hide=guests]texte[/hide]`  
+- `[hide=guests]texte[/hide]`
   → Caché uniquement aux invités/bots, visible à tous les membres connectés
 
-- `[hide=inline]texte[/hide]`  
+- `[hide=inline]texte[/hide]`
   → Caché aux membres n’ayant pas posté et aux invités, s’affiche “en ligne”
 
-- `[hide=guests-inline]texte[/hide]` ou `[hide=inline-guests]texte[/hide]`  
+- `[hide=guests-inline]texte[/hide]` ou `[hide=inline-guests]texte[/hide]`
   → Caché uniquement aux invités/bots, affiché “en ligne” pour les membres connectés
 
 **A noter la présence nécessaire du trait d'union quand on veut guests et inline simultanément.

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Hide Extension Builder" description="Builds an extension.zip from a git repository" default="all">
-	<property name="vendor-name" value="alfredoramos" />
+       <property name="vendor-name" value="noordo" />
 	<property name="extension-name" value="hide" />
 	<!--
 	Only set this to "true" if you have dependencies in the composer.json,

--- a/event/listener.php
+++ b/event/listener.php
@@ -169,32 +169,25 @@ class listener implements EventSubscriberInterface
                        $has_posted = (bool) $this->db->sql_fetchrow($result);
                        $this->db->sql_freeresult($result);
                }
-               //echo "<pre>";
-               //var_dump($renderer);
-               //echo "</pre>";
-               // if (method_exists($renderer, 'setParameter'))
-               // {
-                       // print_r('<br />has_posted2 = '.$has_posted);
-                       // $renderer->setParameter('S_HAS_POSTED', $has_posted);
-                       // $renderer->setParameter('S_IS_ADMIN', $this->auth->acl_get('a_'));
-               // }
-               // else if (property_exists($renderer, 'params'))
-               // {
-                       // print_r('<br />has_posted3 = '.$has_posted);
-                       // $renderer->params['S_HAS_POSTED'] = $has_posted;
-                       // $renderer->params['S_IS_ADMIN'] = $this->auth->acl_get('a_');
-               // }
-               if (method_exists($renderer, 'get_renderer'))
+                if (method_exists($renderer, 'get_renderer'))
                 {
-                    $real_renderer = $renderer->get_renderer();
+                        $real_renderer = $renderer->get_renderer();
 
-                    if (method_exists($real_renderer, 'setParameter'))
-                    {
-                        $real_renderer->setParameter('S_HAS_POSTED', $has_posted);
-                        $real_renderer->setParameter('S_IS_ADMIN', $this->auth->acl_get('a_'));
-                    }
+                        if (method_exists($real_renderer, 'setParameter'))
+                        {
+                                $real_renderer->setParameter('S_HAS_POSTED', $has_posted);
+                                $real_renderer->setParameter('S_IS_ADMIN', $this->auth->acl_get('a_'));
+                        }
                 }
-
-               
+                elseif (method_exists($renderer, 'setParameter'))
+                {
+                        $renderer->setParameter('S_HAS_POSTED', $has_posted);
+                        $renderer->setParameter('S_IS_ADMIN', $this->auth->acl_get('a_'));
+                }
+                elseif (property_exists($renderer, 'params'))
+                {
+                        $renderer->params['S_HAS_POSTED'] = $has_posted;
+                        $renderer->params['S_IS_ADMIN'] = $this->auth->acl_get('a_');
+                }
        }
 }

--- a/language/en/posting.php
+++ b/language/en/posting.php
@@ -29,7 +29,9 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'HIDE' => 'Hide',
-	'HIDE_HELPLINE' => 'Usage: [hide]text[/hide] or [hide inline=1]text[/hide]',
-	'HIDDEN_CONTENT' => 'Hidden content',
+       'HIDE_HELPLINE' => 'Usage: [hide]text[/hide], [hide=guests]text[/hide], [hide=inline]text[/hide] or [hide=guests-inline]text[/hide]',
+       'HIDDEN_CONTENT' => 'Hidden content',
+       'HIDDEN_CONTENT_VISIBLE_GUESTS' => 'Content visible to all logged-in users!',
+       'HIDDEN_CONTENT_VISIBLE_POSTERS' => 'Content visible to the participants of this discussion!',
        'HIDDEN_CONTENT_EXPLAIN' => 'You must participate in this discussion to view hidden content.'
 ]);

--- a/language/es/posting.php
+++ b/language/es/posting.php
@@ -29,7 +29,9 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'HIDE' => 'Ocultar',
-	'HIDE_HELPLINE' => 'Uso: [hide]texto[/hide] o [hide inline=1]texto[/hide]',
-	'HIDDEN_CONTENT' => 'Contenido oculto',
-	'HIDDEN_CONTENT_EXPLAIN' => 'Contenido exclusivo para usuarios registrados.'
+        'HIDE_HELPLINE' => 'Uso: [hide]texto[/hide], [hide=guests]texto[/hide], [hide=inline]texto[/hide] o [hide=guests-inline]texto[/hide]',
+        'HIDDEN_CONTENT' => 'Contenido oculto',
+        'HIDDEN_CONTENT_VISIBLE_GUESTS' => 'Contenido visible para todos los usuarios conectados!',
+        'HIDDEN_CONTENT_VISIBLE_POSTERS' => 'Contenido visible para los participantes en esta discusión!',
+        'HIDDEN_CONTENT_EXPLAIN' => 'Contenido exclusivo para usuarios registrados.'
 ]);

--- a/language/es_x_tu/posting.php
+++ b/language/es_x_tu/posting.php
@@ -29,7 +29,9 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'HIDE' => 'Ocultar',
-	'HIDE_HELPLINE' => 'Uso: [hide]texto[/hide] o [hide inline=1]texto[/hide]',
-	'HIDDEN_CONTENT' => 'Contenido oculto',
-	'HIDDEN_CONTENT_EXPLAIN' => 'Contenido exclusivo para usuarios registrados.'
+        'HIDE_HELPLINE' => 'Uso: [hide]texto[/hide], [hide=guests]texto[/hide], [hide=inline]texto[/hide] o [hide=guests-inline]texto[/hide]',
+        'HIDDEN_CONTENT' => 'Contenido oculto',
+        'HIDDEN_CONTENT_VISIBLE_GUESTS' => 'Contenido visible para todos los usuarios conectados!',
+        'HIDDEN_CONTENT_VISIBLE_POSTERS' => 'Contenido visible para los participantes en esta discusión!',
+        'HIDDEN_CONTENT_EXPLAIN' => 'Contenido exclusivo para usuarios registrados.'
 ]);

--- a/language/et/posting.php
+++ b/language/et/posting.php
@@ -29,7 +29,9 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'HIDE' => 'Peida',
-	'HIDE_HELPLINE' => '[hide]Tekst[/hide] või [hide inline=1]Tekst[/hide]',
-	'HIDDEN_CONTENT' => 'Peidetud sisu',
-	'HIDDEN_CONTENT_EXPLAIN' => 'Sisu sisselogitud kasutajatele.'
+        'HIDE_HELPLINE' => '[hide]Tekst[/hide], [hide=guests]Tekst[/hide], [hide=inline]Tekst[/hide] või [hide=guests-inline]Tekst[/hide]',
+        'HIDDEN_CONTENT' => 'Peidetud sisu',
+        'HIDDEN_CONTENT_VISIBLE_GUESTS' => 'Sisu nähtav kõigile sisse logitud kasutajatele!',
+        'HIDDEN_CONTENT_VISIBLE_POSTERS' => 'Sisu nähtav selle arutelu osalejatele!',
+        'HIDDEN_CONTENT_EXPLAIN' => 'Sisu sisselogitud kasutajatele.'
 ]);

--- a/language/pt_br/posting.php
+++ b/language/pt_br/posting.php
@@ -29,7 +29,9 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, [
 	'HIDE' => 'Ocultar',
-	'HIDE_HELPLINE' => 'Uso: [hide]texto[/hide] ou [hide inline=1]texto[/hide]',
-	'HIDDEN_CONTENT' => 'Conteúdo oculto',
-	'HIDDEN_CONTENT_EXPLAIN' => 'Conteúdo exclusivo para usuários logados.'
+        'HIDE_HELPLINE' => 'Uso: [hide]texto[/hide], [hide=guests]texto[/hide], [hide=inline]texto[/hide] ou [hide=guests-inline]texto[/hide]',
+        'HIDDEN_CONTENT' => 'Conteúdo oculto',
+        'HIDDEN_CONTENT_VISIBLE_GUESTS' => 'Conteúdo visível para todos os usuários logados!',
+        'HIDDEN_CONTENT_VISIBLE_POSTERS' => 'Conteúdo visível para os participantes desta discussão!',
+        'HIDDEN_CONTENT_EXPLAIN' => 'Conteúdo exclusivo para usuários logados.'
 ]);

--- a/tests/event/listener_test.php
+++ b/tests/event/listener_test.php
@@ -7,11 +7,11 @@
  * @license GPL-2.0-only
  */
 
-namespace alfredoramos\hide\tests\event;
+namespace noordo\hide\tests\event;
 
 use phpbb_test_case;
-use alfredoramos\hide\event\listener;
-use alfredoramos\hide\includes\helper;
+use noordo\hide\event\listener;
+use noordo\hide\includes\helper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class listener_test extends phpbb_test_case
 {
-        /** @var \alfredoramos\hide\includes\helper */
+       /** @var \noordo\hide\includes\helper */
         protected $helper;
 
        /** @var \phpbb\db\driver\driver_interface */

--- a/tests/functional/has_posted_view_test.php
+++ b/tests/functional/has_posted_view_test.php
@@ -7,7 +7,7 @@
  * @license GPL-2.0-only
  */
 
-namespace alfredoramos\hide\tests\functional;
+namespace noordo\hide\tests\functional;
 
 /**
  * @group functional
@@ -17,12 +17,12 @@ class has_posted_view_test extends \phpbb_functional_test_case
         protected function setUp(): void
         {
                 parent::setUp();
-                $this->add_lang_ext('alfredoramos/hide', 'posting');
+                $this->add_lang_ext('noordo/hide', 'posting');
         }
 
         static protected function setup_extensions()
         {
-                return ['alfredoramos/hide'];
+                return ['noordo/hide'];
         }
 
         public function test_user_posted_can_view_hidden_content()

--- a/tests/functional/hide_test.php
+++ b/tests/functional/hide_test.php
@@ -7,7 +7,7 @@
  * @license GPL-2.0-only
  */
 
-namespace alfredoramos\hide\tests\functional;
+namespace noordo\hide\tests\functional;
 
 /**
  * @group functional
@@ -17,13 +17,13 @@ class hide_test extends \phpbb_functional_test_case
 	protected function setUp(): void
 	{
 		parent::setUp();
-		$this->add_lang_ext('alfredoramos/hide', 'posting');
+                $this->add_lang_ext('noordo/hide', 'posting');
 		$this->login();
 	}
 
 	static protected function setup_extensions()
 	{
-		return ['alfredoramos/hide'];
+                return ['noordo/hide'];
 	}
 
 	public function test_hide_bbcode()


### PR DESCRIPTION
## Summary
- rename vendor from alfredoramos to noordo
- update language files with new strings
- implement renderer fallback logic
- clean README whitespace
- update tests to new namespace

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883522a2570832887ffc50b7567d1fa